### PR TITLE
Fix examples/color.zig function name compile error.

### DIFF
--- a/examples/color.zig
+++ b/examples/color.zig
@@ -11,9 +11,9 @@ pub fn main() !void {
 
     try stdout.writer().print("{s}Warning text\n", .{color.print.fg(.red)});
 
-    try color.writeFg256(stdout.writer(), .blue);
+    try color.fg256(stdout.writer(), .blue);
     try stdout.writer().print("Blue text\n", .{});
 
-    try color.writeFgRGB(stdout.writer(), 97, 37, 160);
+    try color.fgRGB(stdout.writer(), 97, 37, 160);
     try stdout.writer().print("Purple text\n", .{});
 }


### PR DESCRIPTION
This will allow `zig build color` to run without compilation errors.