### PR TITLE
Update for latest zig

### DIFF
--- a/src/event.zig
+++ b/src/event.zig
@@ -153,6 +153,6 @@ test "next" {
     var i: usize = 0;
     while (i < 3) : (i += 1) {
         const key = try next(stdin.reader());
-        std.debug.print("\n\r{s}\n", .{key});
+        std.debug.print("\n\r{any}\n", .{key});
     }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -8,6 +8,6 @@ pub const utils = @import("utils.zig");
 pub const term = @import("term.zig");
 pub const events = @import("event.zig");
 
-test "" {
+test {
     std.testing.refAllDecls(@This());
 }


### PR DESCRIPTION
Since a couple of weeks ago using `test ""` is forbidden.

I tried running `zig build test` which is how I found the compilation error with the formatting specifier; however [the test](https://github.com/xyaman/mibu/blob/main/src/event.zig#L146-L158) as is doesn't work.
In fact, all tests indirectly calling `os.tcgetattr` fail with the error `NotATerminal` when the binary is called via `zig build test`.
I'm not sure what is intended here.