### PR TITLE
Add partial windows support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -8,18 +8,16 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    if (@import("builtin").os.tag != .windows) {
-        const lib_tests = b.addTest(.{
-            .root_source_file = b.path("src/main.zig"),
-            .target = target,
-            .optimize = optimize,
-        });
+    const lib_tests = b.addTest(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
 
-        const run_lib_tests = b.addRunArtifact(lib_tests);
+    const run_lib_tests = b.addRunArtifact(lib_tests);
 
-        const test_step = b.step("test", "Run library tests");
-        test_step.dependOn(&run_lib_tests.step);
-    }
+    const test_step = b.step("test", "Run library tests");
+    test_step.dependOn(&run_lib_tests.step);
 
     // examples
     const examples = [_][]const u8{

--- a/build.zig
+++ b/build.zig
@@ -8,16 +8,18 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const lib_tests = b.addTest(.{
-        .root_source_file = b.path("src/main.zig"),
-        .target = target,
-        .optimize = optimize,
-    });
+    if (@import("builtin").os.tag != .windows) {
+        const lib_tests = b.addTest(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        });
 
-    const run_lib_tests = b.addRunArtifact(lib_tests);
+        const run_lib_tests = b.addRunArtifact(lib_tests);
 
-    const test_step = b.step("test", "Run library tests");
-    test_step.dependOn(&run_lib_tests.step);
+        const test_step = b.step("test", "Run library tests");
+        test_step.dependOn(&run_lib_tests.step);
+    }
 
     // examples
     const examples = [_][]const u8{

--- a/examples/alternate_screen.zig
+++ b/examples/alternate_screen.zig
@@ -7,20 +7,21 @@ const color = mibu.color;
 const cursor = mibu.cursor;
 
 pub fn main() !void {
-    const stdout = io.getStdOut().writer();
+    const stdout = io.getStdOut();
+    const stdout_wrt = stdout.writer();
 
     if (comptime @import("builtin").os.tag == .windows) {
-        try mibu.term.ensureWindowsVTS(stdout);
+        try mibu.term.ensureWindowsVTS(stdout.handle);
     }
 
-    try term.enterAlternateScreen(stdout);
-    defer term.exitAlternateScreen(stdout) catch unreachable;
+    try term.enterAlternateScreen(stdout_wrt);
+    defer term.exitAlternateScreen(stdout_wrt) catch unreachable;
 
-    try cursor.hide(stdout);
-    defer cursor.show(stdout) catch unreachable;
+    try cursor.hide(stdout_wrt);
+    defer cursor.show(stdout_wrt) catch unreachable;
 
-    try cursor.goTo(stdout, 1, 1);
-    try stdout.print("This is being shown in the alternate screen...", .{});
+    try cursor.goTo(stdout_wrt, 1, 1);
+    try stdout_wrt.print("This is being shown in the alternate screen...", .{});
 
     std.time.sleep(std.time.ns_per_s * 2);
 }

--- a/examples/alternate_screen.zig
+++ b/examples/alternate_screen.zig
@@ -10,8 +10,8 @@ pub fn main() !void {
     const stdout = io.getStdOut();
     const stdout_wrt = stdout.writer();
 
-    if (comptime @import("builtin").os.tag == .windows) {
-        try mibu.term.ensureWindowsVTS(stdout.handle);
+    if (@import("builtin").os.tag == .windows) {
+        try mibu.initWindows(stdout.handle);
     }
 
     try term.enterAlternateScreen(stdout_wrt);

--- a/examples/alternate_screen.zig
+++ b/examples/alternate_screen.zig
@@ -11,7 +11,7 @@ pub fn main() !void {
     const stdout_wrt = stdout.writer();
 
     if (@import("builtin").os.tag == .windows) {
-        try mibu.initWindows(stdout.handle);
+        try mibu.enableWindowsVTS(stdout.handle);
     }
 
     try term.enterAlternateScreen(stdout_wrt);

--- a/examples/alternate_screen.zig
+++ b/examples/alternate_screen.zig
@@ -9,6 +9,10 @@ const cursor = mibu.cursor;
 pub fn main() !void {
     const stdout = io.getStdOut().writer();
 
+    if (comptime @import("builtin").os.tag == .windows) {
+        try mibu.term.ensureWindowsVTS(stdout);
+    }
+
     try term.enterAlternateScreen(stdout);
     defer term.exitAlternateScreen(stdout) catch unreachable;
 

--- a/examples/color.zig
+++ b/examples/color.zig
@@ -9,6 +9,10 @@ const cursor = mibu.cursor;
 pub fn main() !void {
     const stdout = io.getStdOut();
 
+    if (comptime @import("builtin").os.tag == .windows) {
+        try mibu.term.ensureWindowsVTS(stdout.writer());
+    }
+
     try stdout.writer().print("{s}Warning text\n", .{color.print.fg(.red)});
 
     try color.fg256(stdout.writer(), .blue);

--- a/examples/color.zig
+++ b/examples/color.zig
@@ -10,7 +10,7 @@ pub fn main() !void {
     const stdout = io.getStdOut();
 
     if (@import("builtin").os.tag == .windows) {
-        try mibu.initWindows(stdout.handle);
+        try mibu.enableWindowsVTS(stdout.handle);
     }
 
     try stdout.writer().print("{s}Warning text\n", .{color.print.fg(.red)});

--- a/examples/color.zig
+++ b/examples/color.zig
@@ -10,7 +10,7 @@ pub fn main() !void {
     const stdout = io.getStdOut();
 
     if (comptime @import("builtin").os.tag == .windows) {
-        try mibu.term.ensureWindowsVTS(stdout.writer());
+        try mibu.term.ensureWindowsVTS(stdout.handle);
     }
 
     try stdout.writer().print("{s}Warning text\n", .{color.print.fg(.red)});

--- a/examples/color.zig
+++ b/examples/color.zig
@@ -9,8 +9,8 @@ const cursor = mibu.cursor;
 pub fn main() !void {
     const stdout = io.getStdOut();
 
-    if (comptime @import("builtin").os.tag == .windows) {
-        try mibu.term.ensureWindowsVTS(stdout.handle);
+    if (@import("builtin").os.tag == .windows) {
+        try mibu.initWindows(stdout.handle);
     }
 
     try stdout.writer().print("{s}Warning text\n", .{color.print.fg(.red)});

--- a/examples/event.zig
+++ b/examples/event.zig
@@ -16,7 +16,7 @@ pub fn main() !void {
     }
 
     if (@import("builtin").os.tag == .windows) {
-        try mibu.initWindows(stdout.handle);
+        try mibu.enableWindowsVTS(stdout.handle);
     }
 
     // Enable terminal raw mode, its very recommended when listening for events
@@ -30,7 +30,8 @@ pub fn main() !void {
     try stdout.writer().print("Press q or Ctrl-C to exit...\n\r", .{});
 
     while (true) {
-        const next = try events.nextWithTimeout(stdin, 1000);
+        // const next = try events.nextWithTimeout(stdin, 1000);
+        const next = try events.next(stdin);
         switch (next) {
             .key => |k| switch (k) {
                 .char => |c| switch (c) {

--- a/examples/event.zig
+++ b/examples/event.zig
@@ -10,13 +10,13 @@ pub fn main() !void {
     const stdin = io.getStdIn();
     const stdout = io.getStdOut();
 
-    if (@import("builtin").os.tag == .windows) {
-        try term.ensureWindowsVTS(stdout.handle);
-    }
-
     if (!std.posix.isatty(stdin.handle)) {
         try stdout.writer().print("The current file descriptor is not a referring to a terminal.\n", .{});
         return;
+    }
+
+    if (@import("builtin").os.tag == .windows) {
+        try mibu.initWindows(stdout.handle);
     }
 
     // Enable terminal raw mode, its very recommended when listening for events

--- a/examples/event.zig
+++ b/examples/event.zig
@@ -10,6 +10,10 @@ pub fn main() !void {
     const stdin = io.getStdIn();
     const stdout = io.getStdOut();
 
+    if (@import("builtin").os.tag == .windows) {
+        try term.ensureWindowsVTS(stdout.handle);
+    }
+
     if (!std.posix.isatty(stdin.handle)) {
         try stdout.writer().print("The current file descriptor is not a referring to a terminal.\n", .{});
         return;

--- a/src/event.zig
+++ b/src/event.zig
@@ -3,7 +3,6 @@ const io = std.io;
 const windows = std.os.windows;
 
 const cursor = @import("cursor.zig");
-const winapiGlue = @import("winapiGlue.zig");
 
 pub const Event = union(enum) {
     key: Key,

--- a/src/event.zig
+++ b/src/event.zig
@@ -173,7 +173,6 @@ pub fn nextWithTimeout(in: anytype, timeout_ms: i32) !Event {
     switch (@import("builtin").os.tag) {
         .linux => return nextWithTimeoutPosix(in, timeout_ms),
         .macos => return nextWithTimeoutPosix(in, timeout_ms),
-        .windows => return nextWithTimeoutWindows(in, timeout_ms),
         else => return error.UnsupportedPlatform,
     }
 }
@@ -189,10 +188,6 @@ fn nextWithTimeoutPosix(in: anytype, timeout_ms: i32) !Event {
     }
 
     return .none;
-}
-
-fn nextWithTimeoutWindows(_: anytype, _: i32) !Event {
-    return error.UnsupportedPlatform;
 }
 
 /// Returns the next event received.
@@ -437,17 +432,17 @@ fn parseMouseAction(action: u8) !Mouse {
     return mouse_event;
 }
 
-test "next" {
-    const term = @import("main.zig").term;
-
-    const tty = (try std.fs.cwd().openFile("/dev/tty", .{})).reader();
-
-    var raw = try term.enableRawMode(tty.context.handle);
-    defer raw.disableRawMode() catch {};
-
-    var i: usize = 0;
-    while (i < 3) : (i += 1) {
-        const key = try next(tty);
-        std.debug.print("\n\r{any}\n", .{key});
-    }
-}
+// test "next" {
+//     const term = @import("main.zig").term;
+//
+//     const tty = (try std.fs.cwd().openFile("/dev/tty", .{})).reader();
+//
+//     var raw = try term.enableRawMode(tty.context.handle);
+//     defer raw.disableRawMode() catch {};
+//
+//     var i: usize = 0;
+//     while (i < 3) : (i += 1) {
+//         const key = try next(tty);
+//         std.debug.print("\n\r{any}\n", .{key});
+//     }
+// }

--- a/src/main.zig
+++ b/src/main.zig
@@ -8,9 +8,9 @@ pub const utils = @import("utils.zig");
 pub const term = @import("term.zig");
 pub const events = @import("event.zig");
 
-pub const initWindows = switch (@import("builtin").os.tag) {
-    .windows => @import("utils.zig").initWindows,
-    else => undefined,
+pub const enableWindowsVTS = switch (@import("builtin").os.tag) {
+    .windows => @import("utils.zig").enableWindowsVTS,
+    else => @compileError("enableWindowsVTS is supported only on Windows")
 };
 
 test {

--- a/src/main.zig
+++ b/src/main.zig
@@ -9,7 +9,7 @@ pub const term = @import("term.zig");
 pub const events = @import("event.zig");
 
 pub const initWindows = switch (@import("builtin").os.tag) {
-    .windows => @import("utils").initWindows,
+    .windows => @import("utils.zig").initWindows,
     else => undefined,
 };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -8,7 +8,10 @@ pub const utils = @import("utils.zig");
 pub const term = @import("term.zig");
 pub const events = @import("event.zig");
 
-pub const initWindows = @import("utils.zig").initWindows;
+pub const initWindows = switch (@import("builtin").os.tag) {
+    .windows => @import("utils").initWindows,
+    else => undefined,
+};
 
 test {
     std.testing.refAllDecls(@This());

--- a/src/main.zig
+++ b/src/main.zig
@@ -8,6 +8,8 @@ pub const utils = @import("utils.zig");
 pub const term = @import("term.zig");
 pub const events = @import("event.zig");
 
+pub const initWindows = @import("utils.zig").initWindows;
+
 test {
     std.testing.refAllDecls(@This());
 }

--- a/src/term.zig
+++ b/src/term.zig
@@ -7,11 +7,13 @@ const utils = @import("utils.zig");
 
 const builtin = @import("builtin");
 
+pub const ensureWindowsVTS = utils.ensureWindowsVTS;
+
 pub fn enableRawMode(handle: posix.fd_t) !RawTerm {
     const original_termios = try posix.tcgetattr(handle);
 
     var termios = original_termios;
-    
+
     // https://viewsourcecode.org/snaptoken/kilo/02.enteringRawMode.html
     // TCSETATTR(3)
     // reference: void cfmakeraw(struct termios *t)
@@ -84,7 +86,7 @@ pub fn getSize(fd: posix.fd_t) !TermSize {
         .height = ws.row,
     };
 }
-/// Switches to an alternate screen mode in the console. 
+/// Switches to an alternate screen mode in the console.
 /// `out`: needs to be writer
 pub fn enterAlternateScreen(out: anytype) !void {
     try out.print("{s}", .{utils.comptimeCsi("?1049h", .{})});

--- a/src/term.zig
+++ b/src/term.zig
@@ -5,6 +5,7 @@ const posix = std.posix;
 const windows = std.os.windows;
 
 const utils = @import("utils.zig");
+const winapiGlue = @import("winapiGlue.zig");
 
 const builtin = @import("builtin");
 
@@ -94,7 +95,7 @@ fn getSizePosix(fd: posix.fd_t) !TermSize {
 }
 
 fn getSizeWindows(handle: windows.HANDLE) !TermSize {
-    const csbi = try utils.GetConsoleScreenBufferInfoWinApi(handle);
+    const csbi = try winapiGlue.GetConsoleScreenBufferInfoWinApi(handle);
 
     return TermSize{
         .width = @intCast(csbi.srWindow.Right - csbi.srWindow.Left + 1),

--- a/src/term.zig
+++ b/src/term.zig
@@ -9,8 +9,6 @@ const winapiGlue = @import("winapiGlue.zig");
 
 const builtin = @import("builtin");
 
-pub const ensureWindowsVTS = utils.ensureWindowsVTS;
-
 pub fn enableRawMode(handle: std.fs.File.Handle) !RawTerm {
     switch (builtin.os.tag) {
         .linux => return enableRawModePosix(handle),

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -98,6 +98,11 @@ extern "kernel32" fn GetConsoleMode(
     dwMode: *windows.DWORD,
 ) callconv(windows.WINAPI) windows.BOOL;
 
+extern "kernel32" fn GetConsoleScreenBufferInfo(
+    hConsoleOutput: windows.HANDLE,
+    lpConsoleScreenBufferInfo: *windows.CONSOLE_SCREEN_BUFFER_INFO,
+) callconv(windows.WINAPI) windows.BOOL;
+
 const ENABLE_PROCESSED_OUTPUT: windows.DWORD = 0x0001;
 const ENABLE_VIRTUAL_TERMINAL_PROCESSING: windows.DWORD = 0x0004;
 
@@ -116,4 +121,14 @@ pub inline fn ensureWindowsVTS(writer: anytype) !void {
             else => |err| return windows.unexpectedError(err),
         }
     }
+}
+
+pub inline fn GetConsoleScreenBufferInfoWinApi(handle: windows.HANDLE) !windows.CONSOLE_SCREEN_BUFFER_INFO {
+    var csbi: windows.CONSOLE_SCREEN_BUFFER_INFO = undefined;
+    if (GetConsoleScreenBufferInfo(handle, &csbi) == 0) {
+        switch (kernel32.GetLastError()) {
+            else => |err| return windows.unexpectedError(err),
+        }
+    }
+    return csbi;
 }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -88,14 +88,11 @@ pub inline fn comptimeCsi(comptime fmt: []const u8, args: anytype) []const u8 {
 }
 
 /// Ensure that the current console has enabled support for Virtual Terminal Sequencies (VTS).
-pub fn ensureWindowsVTS(handle: windows.HANDLE) !void {
-    const old_mode = try winapiGlue.GetConsoleMode(handle);
+/// https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences#example-of-enabling-virtual-terminal-processing
+/// TODO: should we add a disable method?
+pub fn enableWindowsVTS(handle: windows.HANDLE) !void {
+    const old_mode = try winapiGlue.getConsoleMode(handle);
 
     const mode: windows.DWORD = old_mode | winapiGlue.ENABLE_PROCESSED_OUTPUT | winapiGlue.ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-    try winapiGlue.SetConsoleMode(handle, mode);
-}
-
-/// Sets up the windows Console.
-pub fn initWindows(handle: windows.HANDLE) !void {
-    try ensureWindowsVTS(handle);
+    try winapiGlue.setConsoleMode(handle, mode);
 }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -88,7 +88,7 @@ pub inline fn comptimeCsi(comptime fmt: []const u8, args: anytype) []const u8 {
 }
 
 /// Ensure that the current console has enabled support for Virtual Terminal Sequencies (VTS).
-pub inline fn ensureWindowsVTS(handle: windows.HANDLE) !void {
+pub fn ensureWindowsVTS(handle: windows.HANDLE) !void {
     const old_mode = try winapiGlue.GetConsoleMode(handle);
 
     const mode: windows.DWORD = old_mode | winapiGlue.ENABLE_PROCESSED_OUTPUT | winapiGlue.ENABLE_VIRTUAL_TERMINAL_PROCESSING;

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -88,9 +88,9 @@ pub inline fn comptimeCsi(comptime fmt: []const u8, args: anytype) []const u8 {
 }
 
 /// Ensure that the current console has enabled support for Virtual Terminal Sequencies (VTS).
-pub inline fn ensureWindowsVTS(writer: anytype) !void {
-    const old_mode = try winapiGlue.GetConsoleModeWinApi(writer.context.handle);
+pub inline fn ensureWindowsVTS(handle: windows.HANDLE) !void {
+    const old_mode = try winapiGlue.GetConsoleMode(handle);
 
     const mode: windows.DWORD = old_mode | winapiGlue.ENABLE_PROCESSED_OUTPUT | winapiGlue.ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-    try winapiGlue.SetConsoleModeWinApi(writer.context.handle, mode);
+    try winapiGlue.SetConsoleMode(handle, mode);
 }

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -93,12 +93,24 @@ extern "kernel32" fn SetConsoleMode(
     dwMode: windows.DWORD,
 ) callconv(windows.WINAPI) windows.BOOL;
 
+extern "kernel32" fn GetConsoleMode(
+    hConsoleOutput: windows.HANDLE,
+    dwMode: *windows.DWORD,
+) callconv(windows.WINAPI) windows.BOOL;
+
 const ENABLE_PROCESSED_OUTPUT: windows.DWORD = 0x0001;
 const ENABLE_VIRTUAL_TERMINAL_PROCESSING: windows.DWORD = 0x0004;
 
 /// Ensure that the current console has enabled support for Virtual Terminal Sequencies (VTS).
 pub inline fn ensureWindowsVTS(writer: anytype) !void {
-    const mode: windows.DWORD = ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+    var old_mode: windows.DWORD = 0;
+    if (GetConsoleMode(writer.context.handle, &old_mode) == 0) {
+        switch (kernel32.GetLastError()) {
+            else => |err| return windows.unexpectedError(err),
+        }
+    }
+
+    const mode: windows.DWORD = old_mode | ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
     if (SetConsoleMode(writer.context.handle, mode) == 0) {
         switch (kernel32.GetLastError()) {
             else => |err| return windows.unexpectedError(err),

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -94,3 +94,8 @@ pub inline fn ensureWindowsVTS(handle: windows.HANDLE) !void {
     const mode: windows.DWORD = old_mode | winapiGlue.ENABLE_PROCESSED_OUTPUT | winapiGlue.ENABLE_VIRTUAL_TERMINAL_PROCESSING;
     try winapiGlue.SetConsoleMode(handle, mode);
 }
+
+/// Sets up the windows Console.
+pub fn initWindows(handle: windows.HANDLE) !void {
+    try ensureWindowsVTS(handle);
+}

--- a/src/winapiGlue.zig
+++ b/src/winapiGlue.zig
@@ -1,0 +1,48 @@
+const windows = @import("std").os.windows;
+const kernel32 = windows.kernel32;
+
+extern "kernel32" fn SetConsoleMode(
+    hConsoleOutput: windows.HANDLE,
+    dwMode: windows.DWORD,
+) callconv(windows.WINAPI) windows.BOOL;
+
+extern "kernel32" fn GetConsoleMode(
+    hConsoleOutput: windows.HANDLE,
+    dwMode: *windows.DWORD,
+) callconv(windows.WINAPI) windows.BOOL;
+
+extern "kernel32" fn GetConsoleScreenBufferInfo(
+    hConsoleOutput: windows.HANDLE,
+    lpConsoleScreenBufferInfo: *windows.CONSOLE_SCREEN_BUFFER_INFO,
+) callconv(windows.WINAPI) windows.BOOL;
+
+pub const ENABLE_PROCESSED_OUTPUT: windows.DWORD = 0x0001;
+pub const ENABLE_VIRTUAL_TERMINAL_PROCESSING: windows.DWORD = 0x0004;
+
+pub fn GetConsoleModeWinApi(handle: windows.HANDLE) !windows.DWORD {
+    var mode: windows.DWORD = 0;
+    if (GetConsoleMode(handle, &mode) == 0) {
+        switch (kernel32.GetLastError()) {
+            else => |err| return windows.unexpectedError(err),
+        }
+    }
+    return mode;
+}
+
+pub fn SetConsoleModeWinApi(handle: windows.HANDLE, mode: windows.DWORD) !void {
+    if (SetConsoleMode(handle, mode) == 0) {
+        switch (kernel32.GetLastError()) {
+            else => |err| return windows.unexpectedError(err),
+        }
+    }
+}
+
+pub fn GetConsoleScreenBufferInfoWinApi(handle: windows.HANDLE) !windows.CONSOLE_SCREEN_BUFFER_INFO {
+    var csbi: windows.CONSOLE_SCREEN_BUFFER_INFO = undefined;
+    if (GetConsoleScreenBufferInfo(handle, &csbi) == 0) {
+        switch (kernel32.GetLastError()) {
+            else => |err| return windows.unexpectedError(err),
+        }
+    }
+    return csbi;
+}

--- a/src/winapiGlue.zig
+++ b/src/winapiGlue.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 const windows = std.os.windows;
 const kernel32 = windows.kernel32;
 
@@ -10,30 +11,32 @@ pub const ENABLE_VIRTUAL_TERMINAL_INPUT: windows.DWORD = 0x0200;
 
 pub const DISABLE_NEWLINE_AUTO_RETURN: windows.DWORD = 0x0008;
 
-pub fn GetConsoleMode(handle: windows.HANDLE) !windows.DWORD {
+// https://learn.microsoft.com/en-us/windows/console/getconsolemode
+pub fn getConsoleMode(handle: windows.HANDLE) !windows.DWORD {
     var mode: windows.DWORD = 0;
+
+    // nonzero value means success
     if (kernel32.GetConsoleMode(handle, &mode) == 0) {
-        switch (kernel32.GetLastError()) {
-            else => |err| return windows.unexpectedError(err),
-        }
+        const err = kernel32.GetLastError();
+        return windows.unexpectedError(err);
     }
+
     return mode;
 }
 
-pub fn SetConsoleMode(handle: windows.HANDLE, mode: windows.DWORD) !void {
+pub fn setConsoleMode(handle: windows.HANDLE, mode: windows.DWORD) !void {
+    // nonzero value means success
     if (kernel32.SetConsoleMode(handle, mode) == 0) {
-        switch (kernel32.GetLastError()) {
-            else => |err| return windows.unexpectedError(err),
-        }
+        const err = kernel32.GetLastError();
+        return windows.unexpectedError(err);
     }
 }
 
-pub fn GetConsoleScreenBufferInfo(handle: windows.HANDLE) !windows.CONSOLE_SCREEN_BUFFER_INFO {
+pub fn getConsoleScreenBufferInfo(handle: windows.HANDLE) !windows.CONSOLE_SCREEN_BUFFER_INFO {
     var csbi: windows.CONSOLE_SCREEN_BUFFER_INFO = undefined;
     if (kernel32.GetConsoleScreenBufferInfo(handle, &csbi) == 0) {
-        switch (kernel32.GetLastError()) {
-            else => |err| return windows.unexpectedError(err),
-        }
+        const err = kernel32.GetLastError();
+        return windows.unexpectedError(err);
     }
     return csbi;
 }

--- a/src/winapiGlue.zig
+++ b/src/winapiGlue.zig
@@ -1,27 +1,17 @@
 const windows = @import("std").os.windows;
 const kernel32 = windows.kernel32;
 
-extern "kernel32" fn SetConsoleMode(
-    hConsoleOutput: windows.HANDLE,
-    dwMode: windows.DWORD,
-) callconv(windows.WINAPI) windows.BOOL;
-
-extern "kernel32" fn GetConsoleMode(
-    hConsoleOutput: windows.HANDLE,
-    dwMode: *windows.DWORD,
-) callconv(windows.WINAPI) windows.BOOL;
-
-extern "kernel32" fn GetConsoleScreenBufferInfo(
-    hConsoleOutput: windows.HANDLE,
-    lpConsoleScreenBufferInfo: *windows.CONSOLE_SCREEN_BUFFER_INFO,
-) callconv(windows.WINAPI) windows.BOOL;
-
 pub const ENABLE_PROCESSED_OUTPUT: windows.DWORD = 0x0001;
 pub const ENABLE_VIRTUAL_TERMINAL_PROCESSING: windows.DWORD = 0x0004;
+pub const ENABLE_WINDOW_INPUT: windows.DWORD = 0x0008;
+pub const ENABLE_MOUSE_INPUT: windows.DWORD = 0x0010;
+pub const ENABLE_VIRTUAL_TERMINAL_INPUT: windows.DWORD = 0x0200;
 
-pub fn GetConsoleModeWinApi(handle: windows.HANDLE) !windows.DWORD {
+pub const DISABLE_NEWLINE_AUTO_RETURN: windows.DWORD = 0x0008;
+
+pub fn GetConsoleMode(handle: windows.HANDLE) !windows.DWORD {
     var mode: windows.DWORD = 0;
-    if (GetConsoleMode(handle, &mode) == 0) {
+    if (kernel32.GetConsoleMode(handle, &mode) == 0) {
         switch (kernel32.GetLastError()) {
             else => |err| return windows.unexpectedError(err),
         }
@@ -29,17 +19,17 @@ pub fn GetConsoleModeWinApi(handle: windows.HANDLE) !windows.DWORD {
     return mode;
 }
 
-pub fn SetConsoleModeWinApi(handle: windows.HANDLE, mode: windows.DWORD) !void {
-    if (SetConsoleMode(handle, mode) == 0) {
+pub fn SetConsoleMode(handle: windows.HANDLE, mode: windows.DWORD) !void {
+    if (kernel32.SetConsoleMode(handle, mode) == 0) {
         switch (kernel32.GetLastError()) {
             else => |err| return windows.unexpectedError(err),
         }
     }
 }
 
-pub fn GetConsoleScreenBufferInfoWinApi(handle: windows.HANDLE) !windows.CONSOLE_SCREEN_BUFFER_INFO {
+pub fn GetConsoleScreenBufferInfo(handle: windows.HANDLE) !windows.CONSOLE_SCREEN_BUFFER_INFO {
     var csbi: windows.CONSOLE_SCREEN_BUFFER_INFO = undefined;
-    if (GetConsoleScreenBufferInfo(handle, &csbi) == 0) {
+    if (kernel32.GetConsoleScreenBufferInfo(handle, &csbi) == 0) {
         switch (kernel32.GetLastError()) {
             else => |err| return windows.unexpectedError(err),
         }

--- a/src/winapiGlue.zig
+++ b/src/winapiGlue.zig
@@ -1,4 +1,5 @@
-const windows = @import("std").os.windows;
+const std = @import("std");
+const windows = std.os.windows;
 const kernel32 = windows.kernel32;
 
 pub const ENABLE_PROCESSED_OUTPUT: windows.DWORD = 0x0001;


### PR DESCRIPTION
This PR addresses **Issue #10**.

## Approach for Adding Windows Support

Following the recommendations in the [Windows Console API documentation](https://learn.microsoft.com/en-us/windows/console/classic-vs-vt) and to preserve most of the existing code, I opted for using *Virtual Terminal Sequences* (VTS) rather than the *Classic Console API* wherever feasible.

## Features Now Supported on Windows

- **cursor**: fully supported  
- **color**: fully supported  
- **clear**: fully supported  
- **style**: fully supported  
- **getSize**: fully supported  
- **Raw Mode**: fully supported  
- **event**: partially supported; only the `next` function is implemented, while `nextTimeout` remains unsupported.  

## API Modifications

Efforts were made to minimize changes to the API. The only addition is the `initWindows` function, which configures the Console for VTS support.

An alternative approach considered was to verify VTS support during each function call. However, this would have required maintaining state, leading to further API changes.

## Features Yet to Be Implemented

The `nextTimeout` function is not implemented due to the lack of a reliable polling function in Windows.

**Explored solutions:**  
- Using Zig’s `std.os.windows.poll` was ineffective because it relies on `WSAPoll`, which is limited to sockets.  
- Attempting `WaitForSingleObject` also failed during tests. Rust’s [crossterm](https://github.com/crossterm-rs/crossterm) employs a similar strategy, so additional testing may help.  

## Testing

Tests were disabled on Windows as I couldn't get them to run successfully.  

**Attempted solution:** Using `"CON"` as a substitute for `"/dev/tty"` seemed promising, but when passing the handle to `GetConsoleMode`, it returned error code 5: Access Denied.  
