### PR TITLE
Reworked handling buffer in next()

### DIFF
--- a/examples/event.zig
+++ b/examples/event.zig
@@ -31,7 +31,7 @@ pub fn main() !void {
 
     while (true) {
         // const next = try events.nextWithTimeout(stdin, 1000);
-        const next = try events.next(stdin);
+        const next = try events.next(stdin.reader());
         switch (next) {
             .key => |k| switch (k) {
                 .char => |c| switch (c) {


### PR DESCRIPTION
Fixes #12 

This also changes the code to not use ``File`` as the argument, since it relies on the ``readByte()`` function to be available in ``in``. So ``examples/event.zig`` is also updated.

~~Although I'm unsure how to go about with this line, even though the mouse code seems to work fine for me:~~
```zig
  // const view = try std.unicode.Utf8View.init(buf[0..c]);
    // This is hacky to make mouse code work
    // utf8 view failes to parse mouse events, dont know why, need to check it later
    // TODO: check why utf8 view fails to parse mouse events
    // It's related with the value, if its greater than 127, it fails
    const view = std.unicode.Utf8View.init(buf[0..len]) catch {
        return parseCsi(buf[2..len]);
    };
```

There is a little bit of ugliness trying to switch ``?u8`` values returned from ``readNextOrNull()``, so theres room to improve that