### PR TITLE
feat(termbg): add terminal background color detection

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -19,6 +19,7 @@ pub fn build(b: *std.Build) void {
         "color",
         "event",
         "alternate_screen",
+        "termbg",
     };
 
     for (examples) |example_name| {

--- a/examples/color.zig
+++ b/examples/color.zig
@@ -23,6 +23,6 @@ pub fn main() !void {
     try color.fg256(stdout, .blue);
     try stdout.print("Blue text\n", .{});
 
-    try color.fgRGB(stdout, 97, 37, 160);
+    try color.fgRGB(stdout, .{ .r = 97, .g = 37, .b = 160 });
     try stdout.print("Purple text\n", .{});
 }

--- a/examples/termbg.zig
+++ b/examples/termbg.zig
@@ -1,0 +1,28 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const mibu = @import("mibu");
+
+pub fn main() !void {
+    var stdout_buf: [256]u8 = undefined;
+    const stdin = std.fs.File.stdin();
+    var stdout_file = std.fs.File.stdout();
+    var stdout_writer = stdout_file.writer(&stdout_buf);
+    const out = &stdout_writer.interface;
+
+    if (builtin.os.tag == .windows) {
+        try mibu.enableWindowsVTS(stdout_file.handle);
+    }
+
+    var raw_term = try mibu.term.enableRawMode(stdin.handle);
+    defer raw_term.disableRawMode() catch {};
+
+    const rgb = try mibu.termbg.detect(stdin, stdout_file);
+
+    const t = mibu.termbg.theme(rgb);
+    const rgb8 = rgb.to8();
+
+    try out.print("rgb (16-bit): {}\r\n", .{rgb});
+    try out.print("rgb  (8-bit): {}\r\n", .{rgb8});
+    try out.print("theme: {s}\r\n", .{@tagName(t)});
+    try out.flush();
+}

--- a/src/color.zig
+++ b/src/color.zig
@@ -3,6 +3,17 @@ const fmt = std.fmt;
 
 const utils = @import("main.zig").utils;
 
+/// 8-bit per-channel RGB color for use in ANSI truecolor sequences.
+pub const Rgb = struct {
+    r: u8,
+    g: u8,
+    b: u8,
+
+    pub fn format(this: @This(), writer: *std.io.Writer) std.io.Writer.Error!void {
+        try writer.print("Rgb{{ r: {d}, g: {d}, b: {d} }}", .{ this.r, this.g, this.b });
+    }
+};
+
 /// 256 colors
 /// https://www.ditig.com/256-colors-cheat-sheet
 pub const Color = enum(u8) {
@@ -309,13 +320,13 @@ pub fn bg256(writer: *std.Io.Writer, color: Color) !void {
 }
 
 /// Writes the escape sequence code to change foreground to rgb color
-pub fn fgRGB(writer: *std.Io.Writer, r: u8, g: u8, b: u8) !void {
-    return writer.print(utils.csi ++ utils.fg_rgb ++ "{d};{d};{d}m", .{ r, g, b });
+pub fn fgRGB(writer: *std.Io.Writer, rgb: Rgb) !void {
+    return writer.print(utils.csi ++ utils.fg_rgb ++ "{d};{d};{d}m", .{ rgb.r, rgb.g, rgb.b });
 }
 
 /// Writes the escape sequence code to change background to rgb color
-pub fn bgRGB(writer: *std.Io.Writer, r: u8, g: u8, b: u8) !void {
-    return writer.print(utils.csi ++ utils.bg_rgb ++ "{d};{d};{d}m", .{ r, g, b });
+pub fn bgRGB(writer: *std.Io.Writer, rgb: Rgb) !void {
+    return writer.print(utils.csi ++ utils.bg_rgb ++ "{d};{d};{d}m", .{ rgb.r, rgb.g, rgb.b });
 }
 
 /// Writes the escape code to reset style and color

--- a/src/main.zig
+++ b/src/main.zig
@@ -8,6 +8,7 @@ pub const utils = @import("utils.zig");
 pub const term = @import("term.zig");
 pub const events = @import("event.zig");
 pub const scroll = @import("scroll.zig");
+pub const termbg = @import("termbg.zig");
 
 pub const enableWindowsVTS = switch (@import("builtin").os.tag) {
     .windows => @import("utils.zig").enableWindowsVTS,
@@ -23,4 +24,5 @@ test {
     _ = term;
     _ = events;
     _ = scroll;
+    _ = termbg;
 }

--- a/src/termbg.zig
+++ b/src/termbg.zig
@@ -1,0 +1,187 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const posix = std.posix;
+const windows = std.os.windows;
+const winapiGlue = @import("winapiGlue.zig");
+const color = @import("color.zig");
+
+/// 16-bit per-channel RGB as returned by OSC 11 (values 0–65535).
+/// This is intentionally different from color.Rgb (u8 per channel).
+pub const Rgb16 = struct {
+    r: u16,
+    g: u16,
+    b: u16,
+
+    /// Convert to 8-bit per channel for use with color.fgRGB / color.bgRGB.
+    pub fn to8(self: Rgb16) color.Rgb {
+        return .{
+            .r = @intCast(self.r >> 8),
+            .g = @intCast(self.g >> 8),
+            .b = @intCast(self.b >> 8),
+        };
+    }
+
+    pub fn format(this: @This(), writer: *std.io.Writer) std.io.Writer.Error!void {
+        try writer.print("Rgb16{{ r: {d}, g: {d}, b: {d} }}", .{ this.r, this.g, this.b });
+    }
+};
+
+pub const Theme = enum { dark, light };
+
+/// Query the terminal background color via OSC 11 with a CSI 6n discriminator.
+/// The terminal MUST already be in raw mode before calling this function.
+/// Blocks until a response is received.
+/// Returns error.NotSupported if the terminal ignores OSC 11.
+pub fn detect(input: std.fs.File, output: std.fs.File) !Rgb16 {
+    return detectImpl(input, output, -1);
+}
+
+/// Like detect, but returns error.Timeout if no response arrives within timeout_ms.
+pub fn detectWithTimeout(input: std.fs.File, output: std.fs.File, timeout_ms: u32) !Rgb16 {
+    return detectImpl(input, output, @intCast(timeout_ms));
+}
+
+fn detectImpl(input: std.fs.File, output: std.fs.File, timeout: i32) !Rgb16 {
+    try output.writeAll("\x1b]11;?\x1b\\" ++ "\x1b[6n");
+
+    var buf: [128]u8 = undefined;
+    var n: usize = 0;
+
+    switch (builtin.os.tag) {
+        .linux, .macos => {
+            var polls: [1]posix.pollfd = .{.{
+                .fd = input.handle,
+                .events = posix.POLL.IN,
+                .revents = 0,
+            }};
+            if (try posix.poll(&polls, timeout) == 0) return error.Timeout;
+            n = try input.read(buf[0..]);
+            // If the first read didn't contain the OSC 11 response, keep
+            // polling. This handles ConPTY (WSL) where the cursor position
+            // report (CSI 6n) arrives before the OSC 11 response because
+            // ConPTY answers CSI 6n itself without a terminal round-trip.
+            while (std.mem.indexOf(u8, buf[0..n], "rgb:") == null) {
+                if (n == buf.len) break;
+                if (try posix.poll(&polls, 50) == 0) break;
+                n += try input.read(buf[n..]);
+            }
+        },
+        .windows => {
+            const t: windows.DWORD = if (timeout < 0) winapiGlue.INFINITE else @intCast(timeout);
+            if (winapiGlue.WaitForSingleObject(input.handle, t) == winapiGlue.WAIT_TIMEOUT_VAL) {
+                return error.Timeout;
+            }
+            n = try input.read(buf[0..]);
+            if (n < buf.len and winapiGlue.WaitForSingleObject(input.handle, 50) == winapiGlue.WAIT_OBJECT_0) {
+                n += try input.read(buf[n..]);
+            }
+        },
+        else => return error.UnsupportedPlatform,
+    }
+
+    return try parseOsc11(buf[0..n]);
+}
+
+/// Returns .dark or .light based on WCAG relative luminance of the background.
+pub fn theme(rgb: Rgb16) Theme {
+    const coeff = [3]f64{ 0.2126, 0.7152, 0.0722 };
+    const channels = [3]f64{
+        @as(f64, @floatFromInt(rgb.r)) / 65535.0,
+        @as(f64, @floatFromInt(rgb.g)) / 65535.0,
+        @as(f64, @floatFromInt(rgb.b)) / 65535.0,
+    };
+    var sum: f64 = 0;
+    for (channels, coeff) |x, c| {
+        sum += (if (x == 0) 0 else @exp(@log(x) * 2.2)) * c;
+    }
+    const lum = @round(sum * 1000.0) / 1000.0;
+    return if (lum < 0.36) .dark else .light;
+}
+
+fn parseOsc11(buf: []const u8) !Rgb16 {
+    const idx = std.mem.indexOf(u8, buf, "rgb:") orelse return error.NotSupported;
+    const rest = buf[idx + 4 ..];
+
+    const s1 = std.mem.indexOfScalar(u8, rest, '/') orelse return error.InvalidFormat;
+    const r = parseHexChannel(rest[0..s1]) catch return error.InvalidFormat;
+
+    const rest2 = rest[s1 + 1 ..];
+    const s2 = std.mem.indexOfScalar(u8, rest2, '/') orelse return error.InvalidFormat;
+    const g = parseHexChannel(rest2[0..s2]) catch return error.InvalidFormat;
+
+    const rest3 = rest2[s2 + 1 ..];
+    var b_end: usize = 0;
+    while (b_end < rest3.len and b_end < 4) : (b_end += 1) {
+        const c = rest3[b_end];
+        // check if it's hex char
+        if (!((c >= '0' and c <= '9') or (c >= 'a' and c <= 'f') or (c >= 'A' and c <= 'F'))) break;
+    }
+
+    const b = parseHexChannel(rest3[0..b_end]) catch return error.InvalidFormat;
+
+    return Rgb16{ .r = r, .g = g, .b = b };
+}
+
+/// Parse 1–4 hex digits and normalise to u16.
+fn parseHexChannel(s: []const u8) !u16 {
+    if (s.len == 0 or s.len > 4) return error.InvalidFormat;
+    const val = try std.fmt.parseInt(u16, s, 16);
+    return if (s.len <= 2) (val << 8) | val else val;
+}
+
+test "parseOsc11 black background (16-bit)" {
+    const buf = "\x1b]11;rgb:0000/0000/0000\x07";
+    const rgb = try parseOsc11(buf);
+    try std.testing.expectEqual(@as(u16, 0x0000), rgb.r);
+    try std.testing.expectEqual(@as(u16, 0x0000), rgb.g);
+    try std.testing.expectEqual(@as(u16, 0x0000), rgb.b);
+}
+
+test "parseOsc11 white background (16-bit)" {
+    const buf = "\x1b]11;rgb:ffff/ffff/ffff\x07";
+    const rgb = try parseOsc11(buf);
+    try std.testing.expectEqual(@as(u16, 0xffff), rgb.r);
+    try std.testing.expectEqual(@as(u16, 0xffff), rgb.g);
+    try std.testing.expectEqual(@as(u16, 0xffff), rgb.b);
+}
+
+test "parseOsc11 white background (8-bit legacy)" {
+    const buf = "\x1b]11;rgb:ff/ff/ff\x07";
+    const rgb = try parseOsc11(buf);
+    try std.testing.expectEqual(@as(u16, 0xffff), rgb.r);
+    try std.testing.expectEqual(@as(u16, 0xffff), rgb.g);
+    try std.testing.expectEqual(@as(u16, 0xffff), rgb.b);
+}
+
+test "parseOsc11 typical dark background" {
+    const buf = "\x1b]11;rgb:1e1e/1e1e/2e2e\x1b\\";
+    const rgb = try parseOsc11(buf);
+    try std.testing.expectEqual(@as(u16, 0x1e1e), rgb.r);
+    try std.testing.expectEqual(@as(u16, 0x1e1e), rgb.g);
+    try std.testing.expectEqual(@as(u16, 0x2e2e), rgb.b);
+}
+
+test "parseOsc11 with surrounding CSI 6n response" {
+    const buf = "\x1b]11;rgb:ffff/ffff/ffff\x07\x1b[35;80R";
+    const rgb = try parseOsc11(buf);
+    try std.testing.expectEqual(@as(u16, 0xffff), rgb.r);
+    try std.testing.expectEqual(@as(u16, 0xffff), rgb.g);
+    try std.testing.expectEqual(@as(u16, 0xffff), rgb.b);
+}
+
+test "parseOsc11 not supported (only CSI 6n)" {
+    const buf = "\x1b[35;80R";
+    try std.testing.expectError(error.NotSupported, parseOsc11(buf));
+}
+
+test "parseHexChannel 8-bit to 16-bit expansion" {
+    try std.testing.expectEqual(@as(u16, 0xffff), try parseHexChannel("ff"));
+    try std.testing.expectEqual(@as(u16, 0x0000), try parseHexChannel("00"));
+    try std.testing.expectEqual(@as(u16, 0x8080), try parseHexChannel("80"));
+}
+
+test "parseHexChannel 16-bit passthrough" {
+    try std.testing.expectEqual(@as(u16, 0xffff), try parseHexChannel("ffff"));
+    try std.testing.expectEqual(@as(u16, 0x0000), try parseHexChannel("0000"));
+    try std.testing.expectEqual(@as(u16, 0x1e1e), try parseHexChannel("1e1e"));
+}


### PR DESCRIPTION
Adds `termbg` module to detect terminal background color via OSC 11.

## Testing
- Windows: `zig build termbg` works on Windows Terminal
- WSL/Linux: it returns `error.NotSupported` (but: `printf "\033]11;?\007"` also failed, so maybe is okay? I will test on real linux machine later.

